### PR TITLE
add accelerated Rainforth

### DIFF
--- a/examples/contrib/oed/eig_estimation_benchmarking.py
+++ b/examples/contrib/oed/eig_estimation_benchmarking.py
@@ -80,6 +80,7 @@ X_circle_5d_1n_2p = torch.stack([item_thetas_small.cos(), -item_thetas_small.sin
 
 # Location finding designs
 loc_15d_1n_2p = torch.stack([torch.linspace(-15., 15., 15), torch.ones(15)], dim=-1).unsqueeze(-2)
+print(loc_15d_1n_2p[5, ...])
 loc_4d_1n_2p = torch.tensor([[-5., 1], [-4.9, 1.], [4.9, 1], [5., 1.]]).unsqueeze(-2)
 
 #########################################################################################
@@ -119,7 +120,7 @@ logistic_random_effects = logistic_regression_model([torch.tensor([1.]), torch.t
                                                     coef_labels=["coef", "loc"])
 loc_ba_guide = lambda d: LinearModelGuide(d, {"w1": 2})  # noqa: E731
 logistic_guide  = lambda d: LogisticGuide(d, {"w1": 2})
-logistic_random_effect_guide = lambda d: LogisticGuide(d, {"loc": 1})
+logistic_random_effect_guide = lambda d: LogisticGuide(d, {"coef": 1, "loc": 1})
 logistic_response_est = lambda d: LogisticResponseEst(d, ["y"])
 logistic_cond_response_est = lambda d: LogisticCondResponseEst(d, {"coef": 1, "loc": 1}, ["y"])
 sigmoid_response_est = lambda d: SigmoidResponseEst(d, ["y"])
@@ -157,16 +158,33 @@ T = namedtuple("CompareEstimatorsExample", [
 ])
 
 CMP_TEST_CASES = [
-      T(
+    T(
+        "Logistic with random effects",
+        logistic_random_effects,
+        loc_15d_1n_2p,
+        "y",
+        "loc",
+        [
+            (accelerated_rainforth_eig, [{"y": torch.tensor([0., 1.])}, 100, 100]),
+            (accelerated_rainforth_eig, [{"y": torch.tensor([0., 1.])}, 500, 500]),
+            (gibbs_y_re_eig,
+             [40, 1200, logistic_response_est(15), logistic_cond_response_est(15),
+              optim.Adam({"lr": 0.05}), False, None, 500]),
+            (ba_eig_mc,
+             [40, 800, logistic_random_effect_guide(15), optim.Adam({"lr": 0.05}),
+              False, None, 500]),
+        ]
+    ),
+    T(
         "Logistic regression",
         logistic_2p_model,
         loc_15d_1n_2p,
         "y",
         "w1",
         [
-            (accelerated_rainforth_eig, [{"y": torch.tensor([0., 1.])}, 500, 500]),
+            (accelerated_rainforth_eig, [{"y": torch.tensor([0., 1.])}, 2000]),
             (gibbs_y_eig,
-             [40, 100, logistic_response_est(15), optim.Adam({"lr": 0.05}),
+             [40, 400, logistic_response_est(15), optim.Adam({"lr": 0.05}),
               False, None, 500]),
             (ba_eig_mc,
              [40, 800, logistic_guide(15), optim.Adam({"lr": 0.05}),
@@ -175,15 +193,14 @@ CMP_TEST_CASES = [
             # [400, 400, GuideDV(logistic_guide(15)),
             #  optim.Adam({"lr": 0.05}), False, None, 500]),
         ]
-    ),    
-        
+    ),
     T(
         "Sigmoid with random effects",
         sigmoid_high_random_effects,
         loc_15d_1n_2p,
         "y",
         "loc",
-        [
+        [  
             (gibbs_y_re_eig,
              [40, 1600, sigmoid_response_est(15), sigmoid_cond_response_est(15),
               optim.Adam({"lr": 0.05}), False, None, 500]),
@@ -191,6 +208,7 @@ CMP_TEST_CASES = [
              [40, 800, sigmoid_random_effect_guide(15), optim.Adam({"lr": 0.05}),
               False, None, 500]),
             (naive_rainforth_eig, [500, 500, 500])
+            
             # (gibbs_y_re_eig,
             #  [40, 32000, sigmoid_response_est(15), sigmoid_cond_response_est(15),
             #   optim.Adam({"lr": 0.05}), False, None, 500]),
@@ -198,7 +216,7 @@ CMP_TEST_CASES = [
             #  [40, 16000, sigmoid_random_effect_guide(15), optim.Adam({"lr": 0.05}),
             #   False, None, 500])
         ]
-    ),
+    ),  
     T(
         "Sigmoid link function: location finding with 1d response",
         sigmoid_high_2p_model,
@@ -216,21 +234,6 @@ CMP_TEST_CASES = [
             #(donsker_varadhan_eig,
             # [400, 80, GuideDV(sigmoid_high_guide(15)),
             #  optim.Adam({"lr": 0.05}), False, None, 500])
-        ]
-    ),
-    T(
-        "Logistic with random effects",
-        logistic_random_effects,
-        loc_15d_1n_2p,
-        "y",
-        "loc",
-        [
-            (gibbs_y_re_eig,
-             [40, 1200, logistic_response_est(15), logistic_cond_response_est(15),
-              optim.Adam({"lr": 0.05}), False, None, 500]),
-            (ba_eig_mc,
-             [40, 800, logistic_random_effect_guide(15), optim.Adam({"lr": 0.05}),
-              False, None, 500]),
         ]
     ),
   

--- a/examples/contrib/oed/eig_estimation_benchmarking.py
+++ b/examples/contrib/oed/eig_estimation_benchmarking.py
@@ -10,7 +10,7 @@ import pyro
 from pyro import optim
 from pyro.infer import TraceEnum_ELBO
 from pyro.contrib.oed.eig import (
-    vi_ape, naive_rainforth_eig, donsker_varadhan_eig, barber_agakov_ape, gibbs_y_eig,
+    vi_ape, naive_rainforth_eig, accelerated_rainforth_eig, donsker_varadhan_eig, barber_agakov_ape, gibbs_y_eig,
     gibbs_y_re_eig
 )
 from pyro.contrib.oed.util import (
@@ -143,6 +143,7 @@ barber_agakov_ape.name = "Barber-Agakov"
 donsker_varadhan_eig.name = "Donsker-Varadhan"
 linear_model_ground_truth.name = "Ground truth"
 naive_rainforth_eig.name = "Naive Rainforth"
+accelerated_rainforth_eig.name = "Accelerated Rainforth"
 gibbs_y_eig.name = "Gibbs y"
 gibbs_y_re_eig.name = "Gibbs y with random effects"
 
@@ -156,6 +157,26 @@ T = namedtuple("CompareEstimatorsExample", [
 ])
 
 CMP_TEST_CASES = [
+      T(
+        "Logistic regression",
+        logistic_2p_model,
+        loc_15d_1n_2p,
+        "y",
+        "w1",
+        [
+            (accelerated_rainforth_eig, [{"y": torch.tensor([0., 1.])}, 500, 500]),
+            (gibbs_y_eig,
+             [40, 100, logistic_response_est(15), optim.Adam({"lr": 0.05}),
+              False, None, 500]),
+            (ba_eig_mc,
+             [40, 800, logistic_guide(15), optim.Adam({"lr": 0.05}),
+              False, None, 500]),
+            # (donsker_varadhan_eig,
+            # [400, 400, GuideDV(logistic_guide(15)),
+            #  optim.Adam({"lr": 0.05}), False, None, 500]),
+        ]
+    ),    
+        
     T(
         "Sigmoid with random effects",
         sigmoid_high_random_effects,
@@ -169,6 +190,7 @@ CMP_TEST_CASES = [
             (ba_eig_mc,
              [40, 800, sigmoid_random_effect_guide(15), optim.Adam({"lr": 0.05}),
               False, None, 500]),
+            (naive_rainforth_eig, [500, 500, 500])
             # (gibbs_y_re_eig,
             #  [40, 32000, sigmoid_response_est(15), sigmoid_cond_response_est(15),
             #   optim.Adam({"lr": 0.05}), False, None, 500]),
@@ -190,6 +212,7 @@ CMP_TEST_CASES = [
             (ba_eig_mc,
              [40, 800, sigmoid_high_guide(15), optim.Adam({"lr": 0.05}),
               False, None, 500]),
+            (naive_rainforth_eig, [2000, 2000])
             #(donsker_varadhan_eig,
             # [400, 80, GuideDV(sigmoid_high_guide(15)),
             #  optim.Adam({"lr": 0.05}), False, None, 500])
@@ -210,24 +233,7 @@ CMP_TEST_CASES = [
               False, None, 500]),
         ]
     ),
-    T(
-        "Logistic regression",
-        logistic_2p_model,
-        loc_15d_1n_2p,
-        "y",
-        "w1",
-        [
-            (gibbs_y_eig,
-             [40, 100, logistic_response_est(15), optim.Adam({"lr": 0.05}),
-              False, None, 500]),
-            (ba_eig_mc,
-             [40, 800, logistic_guide(15), optim.Adam({"lr": 0.05}),
-              False, None, 500]),
-            # (donsker_varadhan_eig,
-            # [400, 400, GuideDV(logistic_guide(15)),
-            #  optim.Adam({"lr": 0.05}), False, None, 500]),
-        ]
-    ),
+  
     T(
         "A/B test linear model with known observation variance",
         basic_2p_linear_model_sds_10_2pt5,

--- a/examples/contrib/oed/eig_estimation_benchmarking.py
+++ b/examples/contrib/oed/eig_estimation_benchmarking.py
@@ -80,7 +80,6 @@ X_circle_5d_1n_2p = torch.stack([item_thetas_small.cos(), -item_thetas_small.sin
 
 # Location finding designs
 loc_15d_1n_2p = torch.stack([torch.linspace(-15., 15., 15), torch.ones(15)], dim=-1).unsqueeze(-2)
-print(loc_15d_1n_2p[5, ...])
 loc_4d_1n_2p = torch.tensor([[-5., 1], [-4.9, 1.], [4.9, 1], [5., 1.]]).unsqueeze(-2)
 
 #########################################################################################
@@ -120,7 +119,7 @@ logistic_random_effects = logistic_regression_model([torch.tensor([1.]), torch.t
                                                     coef_labels=["coef", "loc"])
 loc_ba_guide = lambda d: LinearModelGuide(d, {"w1": 2})  # noqa: E731
 logistic_guide  = lambda d: LogisticGuide(d, {"w1": 2})
-logistic_random_effect_guide = lambda d: LogisticGuide(d, {"coef": 1, "loc": 1})
+logistic_random_effect_guide = lambda d: LogisticGuide(d, {"loc": 1})
 logistic_response_est = lambda d: LogisticResponseEst(d, ["y"])
 logistic_cond_response_est = lambda d: LogisticCondResponseEst(d, {"coef": 1, "loc": 1}, ["y"])
 sigmoid_response_est = lambda d: SigmoidResponseEst(d, ["y"])
@@ -166,7 +165,6 @@ CMP_TEST_CASES = [
         "loc",
         [
             (accelerated_rainforth_eig, [{"y": torch.tensor([0., 1.])}, 100, 100]),
-            (accelerated_rainforth_eig, [{"y": torch.tensor([0., 1.])}, 500, 500]),
             (gibbs_y_re_eig,
              [40, 1200, logistic_response_est(15), logistic_cond_response_est(15),
               optim.Adam({"lr": 0.05}), False, None, 500]),
@@ -208,13 +206,6 @@ CMP_TEST_CASES = [
              [40, 800, sigmoid_random_effect_guide(15), optim.Adam({"lr": 0.05}),
               False, None, 500]),
             (naive_rainforth_eig, [500, 500, 500])
-            
-            # (gibbs_y_re_eig,
-            #  [40, 32000, sigmoid_response_est(15), sigmoid_cond_response_est(15),
-            #   optim.Adam({"lr": 0.05}), False, None, 500]),
-            # (ba_eig_mc,
-            #  [40, 16000, sigmoid_random_effect_guide(15), optim.Adam({"lr": 0.05}),
-            #   False, None, 500])
         ]
     ),  
     T(

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -95,9 +95,7 @@ def naive_rainforth_eig(model, design, observation_labels, target_labels=None,
         \\frac{1}{N}\\sum_{n=1}^N \\log \\left(\\frac{1}{M}\\sum_{m=1}^{M}
         p(y_n | \\theta_m, \\widetilde{\\theta}_{m}, d)\\right)
 
-    Monte Carlo estimation is attempted for the :math:`\\log p(y | \\theta, d)` term if
-    the parameter `M_prime` is passed. Otherwise, it is assumed that that :math:`\\log p(y | \\theta, d)`
-    can safely be read from the model itself.
+    The latter form is used when `M_prime != None`.
 
     :param function model: A pyro model accepting `design` as only argument.
     :param torch.Tensor design: Tensor representation of design
@@ -178,9 +176,7 @@ def accelerated_rainforth_eig(model, design, observation_labels, target_labels,
         \\sum_{y=1}^{|Y|}\\left(\\left( \\frac{1}{N}\\sum_{n=1}^N p(y | \\theta_n, \\widetilde{\\theta}_{n}, d)\\right)
         \\log \\left(\\frac{1}{N}\\sum_{n=1}^N p(y | \\theta_n, \\widetilde{\\theta}_{n}, d)\\right)\\right)
 
-    Monte Carlo estimation is attempted for the :math:`\\log p(y | \\theta, d)` term if
-    the parameter `M_prime` is passed. Otherwise, it is assumed that that :math:`\\log p(y | \\theta, d)`
-    can safely be read from the model itself.
+    The latter form is used when `M_prime != None`.
 
     :param function model: A pyro model accepting `design` as only argument.
     :param torch.Tensor design: Tensor representation of design
@@ -544,13 +540,15 @@ def logsumexp(inputs, dim=None, keepdim=False):
 
 
 def xexpx(a):
-    """This function makes the outputs more stable when the inputs of this function converge to -infinity
+    """Computes `a*exp(a)`.
+    
+    This function makes the outputs more stable when the inputs of this function converge to -infinity
 
     Args:
-        a: Tensor
+        a: torch.Tensor
 
     Returns:
-        Equivalent of 'x*expx(a)'.
+        Equivalent of `a*torch.exp(a)`.
     """
     mask = (a == float('-inf'))
     y = a*torch.exp(a)

--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -79,12 +79,14 @@ def naive_rainforth_eig(model, design, observation_labels, target_labels=None,
                         N=100, M=10, M_prime=None):
     """
     Naive Rainforth (i.e. Nested Monte Carlo) estimate of the expected information
-    gain (EIG). The estimate is
+    gain (EIG). The estimate is, when there are not any random effects,
 
     .. math::
 
         \\frac{1}{N}\\sum_{n=1}^N \\log p(y_n | \\theta_n, d) -
         \\frac{1}{N}\\sum_{n=1}^N \\log \\left(\\frac{1}{M}\\sum_{m=1}^M p(y_n | \\theta_m, d)\\right)
+
+    The estimate is, in the presence of random effects,
 
     .. math::
 
@@ -158,13 +160,15 @@ def accelerated_rainforth_eig(model, design, observation_labels, target_labels,
                               yspace, N=100, M_prime=None):
     """
     Accelerated Rainforth (i.e. Unnested Monte Carlo) estimate of the expected information
-    gain (EIG). The estimate is
+    gain (EIG). The estimate is, when there are not any random effects,
 
     .. math::
 
             \\frac{1}{N}\\sum_{n=1}^N\\sum_{y=1}^{|Y|}p(y | \\theta_n, d) \\log p(y | \\theta_n, d)-
             \\sum_{y=1}^{|Y|}\\left[ \\left( \\frac{1}{N} \\sum_{n=1}^N p(y | \\theta_n, d)\\right)
             log\\left(\\frac{1}{N}\\sum_{n=1}^N p(y | \\theta_n, d)\\right)\\right]
+
+    The estimate is, in the presence of random effects,
 
     .. math::
 

--- a/tests/contrib/oed/test_xexpx.py
+++ b/tests/contrib/oed/test_xexpx.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Oct 30 10:52:27 2018
+
+@author: charlinelelan
+"""
+import torch
+
+from pyro.contrib.oed.eig import xexpx
+
+
+def test_xexpx():
+    input1 = torch.tensor([float('-inf')])
+    output1 = torch.tensor([0.])
+    assert xexpx(input1) == output1
+    input2 = torch.tensor([0.])
+    output2 = torch.tensor([0.])
+    assert xexpx(input2) == output2
+    input3 = torch.tensor([1.])
+    output3 = torch.exp(torch.tensor([1.]))
+    assert xexpx(input3) == output3


### PR DESCRIPTION
Accelerated Rainforth with and without random effects implemented and tested on a logistic regression example. The results were consistent with other methods. Next steps: try it on other finite space examples.