### PR TITLE
Add missing import.

### DIFF
--- a/pyro/contrib/oed/eig.py
+++ b/pyro/contrib/oed/eig.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pickle
 import torch
+import math
 
 import pyro
 from pyro import poutine


### PR DESCRIPTION
Minor fix. Required to make e.g. the `item_reponse.py` example run.